### PR TITLE
Change lineage mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out/
 CurrentSim.jl
+parameters.txt

--- a/fastaWriter.jl
+++ b/fastaWriter.jl
@@ -4,7 +4,7 @@ cell_mutations = CSV.File("out/cell_mutations_100.tsv", delim="\t")
 fasta_output = open("cell_mutations.fasta", "a")
 for row in cell_mutations
     cell_id = row[1]
-    write(fasta_output, string(">Cell", cell_id, "\n"))
+    write(fasta_output, string(">", cell_id, "\n"))
     parent_mutations = []
     new_mutations = []
     mutations_present = zeros(Int, 266)
@@ -30,3 +30,4 @@ for row in cell_mutations
 end
 
 close(fasta_output)
+

--- a/parameters.txt
+++ b/parameters.txt
@@ -1,4 +1,4 @@
-popSize = 100
+popSize = 10
 detLim = 5
 d0 = 0.1
 initial_mut=0


### PR DESCRIPTION
## Changes
Changed the way in which lineage is tracked. Modify the existing `cancercell` structure instead of creating a new one. All cells are added into the `cells` vector and marked as either a "parent" or "dead", and are never picked again. The previous use of an additional `history` vector made work much more complicated.